### PR TITLE
Remove outdated Firefox's styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,4 @@
 
 ### 0.0.0 (May 10, 2020)
 
-* Initial release.
+* Remove the styles that were added to Firefox's default stylesheet: [#1](https://github.com/Ismail-elkorchi/new-normalize/pull/1),[#2](https://github.com/Ismail-elkorchi/new-normalize/pull/2).

--- a/new-normalize.css
+++ b/new-normalize.css
@@ -34,7 +34,7 @@ main {
 
 /**
  * Correct the font size and margin on `h1` elements within `section` and
- * `article` contexts in Chrome, Firefox, and Safari.
+ * `article` contexts in Chrome, and Safari.
  */
 
 h1 {
@@ -311,7 +311,7 @@ textarea {
    ========================================================================== */
 
 /*
- * Add the correct display in Edge, IE 10+, and Firefox.
+ * Add the correct display in Edge, and IE 10+.
  */
 
 details {


### PR DESCRIPTION
This PR is a follow up of https://github.com/Ismail-elkorchi/new-normalize/pull/1. It removes all the styles that were added to Firefox's default styles.