### PR TITLE
Remove outdated Chrome's styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,5 @@
 
 ### 0.0.0 (May 10, 2020)
 
+* Remove outdated Chrome's styles: [#1](https://github.com/Ismail-elkorchi/new-normalize/pull/3).
 * Remove the styles that were added to Firefox's default stylesheet: [#1](https://github.com/Ismail-elkorchi/new-normalize/pull/1),[#2](https://github.com/Ismail-elkorchi/new-normalize/pull/2).

--- a/new-normalize.css
+++ b/new-normalize.css
@@ -34,7 +34,7 @@ main {
 
 /**
  * Correct the font size and margin on `h1` elements within `section` and
- * `article` contexts in Chrome, and Safari.
+ * `article` contexts in Safari.
  */
 
 h1 {
@@ -75,14 +75,12 @@ a {
 }
 
 /**
- * 1. Remove the bottom border in Chrome 57-
- * 2. Add the correct text decoration in Chrome, Edge, IE, Opera, and Safari.
+ * 1. Add the correct text decoration in Chrome, Edge, IE, Opera, and Safari.
  */
 
 abbr[title] {
-  border-bottom: none; /* 1 */
-  text-decoration: underline; /* 2 */
-  text-decoration: underline dotted; /* 2 */
+  text-decoration: underline; /* 1 */
+  text-decoration: underline dotted; /* 1 */
 }
 
 /**


### PR DESCRIPTION
Remove a property that targeted Chrome 57- and those that were added to Chrome's default stylesheet.

See : [Chrome built-in stylesheet](https://chromium.googlesource.com/chromium/blink/+/master/Source/core/css/html.css).