### PR TITLE
Remove h1 normalization for Safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,5 +2,6 @@
 
 ### 0.0.0 (May 10, 2020)
 
+* Remove h1 normalization for Safari: [#1](https://github.com/Ismail-elkorchi/new-normalize/pull/4).
 * Remove outdated Chrome's styles: [#1](https://github.com/Ismail-elkorchi/new-normalize/pull/3).
 * Remove the styles that were added to Firefox's default stylesheet: [#1](https://github.com/Ismail-elkorchi/new-normalize/pull/1),[#2](https://github.com/Ismail-elkorchi/new-normalize/pull/2).

--- a/new-normalize.css
+++ b/new-normalize.css
@@ -32,16 +32,6 @@ main {
   display: block;
 }
 
-/**
- * Correct the font size and margin on `h1` elements within `section` and
- * `article` contexts in Safari.
- */
-
-h1 {
-  font-size: 2em;
-  margin: 0.67em 0;
-}
-
 /* Grouping content
    ========================================================================== */
 


### PR DESCRIPTION
Those styles were added to Safari's default stylesheet.

See : [Safari built-in stylesheet](https://trac.webkit.org/browser/trunk/Source/WebCore/css/html.css).